### PR TITLE
Add Hugging Face model support

### DIFF
--- a/mass_tagger.py
+++ b/mass_tagger.py
@@ -14,6 +14,7 @@ os.environ["TF_XLA_FLAGS"] = "--tf_xla_auto_jit=2 --tf_xla_cpu_global_jit"
 # os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
 
 import tensorflow as tf
+from huggingface_hub import snapshot_download
 
 from Generator.TFDataReader import DataGenerator
 
@@ -100,7 +101,14 @@ glob_pattern = "**/*" if args.recursive else "*"
 dry_run = args.dry_run
 
 model_folder = args.model_folder
+if not Path(model_folder).exists():
+    print(f"Downloading model '{model_folder}' from Hugging Face...")
+    model_folder = snapshot_download(repo_id=model_folder)
 labels_file = args.tags_csv
+if not Path(labels_file).is_file():
+    candidate = Path(model_folder) / labels_file
+    if candidate.is_file():
+        labels_file = str(candidate)
 threshold = args.threshold
 batch_size = args.batch_size
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 pandas
 tensorflow < 2.11
 tensorflow-io ~= 0.27.0
+huggingface-hub


### PR DESCRIPTION
## Summary
- allow downloading tagger models from Hugging Face if `--model-folder` is not found
- load `selected_tags.csv` from the downloaded model folder automatically
- add `huggingface-hub` to dependencies

## Testing
- `python3 -m py_compile mass_tagger.py Generator/TFDataReader.py`

------
https://chatgpt.com/codex/tasks/task_e_6865474b41e08330b45b9435a9a71d7e