### PR TITLE
Fix dataset batching

### DIFF
--- a/Generator/TFDataReader.py
+++ b/Generator/TFDataReader.py
@@ -109,7 +109,7 @@ class DataGenerator:
         )
 
         images_list = images_data.batch(
-            self.batch_size, drop_remainder=False, num_parallel_calls=tf.data.AUTOTUNE
+            self.batch_size, drop_remainder=False
         )
         images_list = images_list.prefetch(tf.data.AUTOTUNE)
         return images_list


### PR DESCRIPTION
## Summary
- remove invalid `num_parallel_calls` from batch call

## Testing
- `python3 -m py_compile mass_tagger.py gradio_app.py Generator/TFDataReader.py`


------
https://chatgpt.com/codex/tasks/task_e_68655d86ad308330a2e8301cb95278a5