### PR TITLE
Remove unused numpy import

### DIFF
--- a/mass_tagger.py
+++ b/mass_tagger.py
@@ -24,7 +24,6 @@ KAOMOJIS = [
     "||_||",
 ]
 
-import numpy as np
 import pandas as pd
 from tqdm import tqdm
 


### PR DESCRIPTION
## Summary
- drop unused numpy import from `mass_tagger.py`
- confirm `np` is not referenced via `pyflakes`

## Testing
- `pyflakes mass_tagger.py`

------
https://chatgpt.com/codex/tasks/task_e_68656cfc30b88330858fdbfa4071eecb