### PR TITLE
Switch to files input for batch tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ python3 gradio_app.py
 ```
 
 This starts a local server where you can configure the options interactively and run the tagger through a browser interface.
+
+In the *Batch Tag* tab, use the **Images** file uploader to select the pictures you want to tag. The selected files are processed on the server and the resulting tags are written next to each uploaded image.

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -6,7 +6,7 @@ from mass_tagger import tag_images, _load_model
 
 
 def run(
-    targets_path,
+    files,
     recursive,
     dry_run,
     model_folder,
@@ -14,9 +14,19 @@ def run(
     threshold,
     batch_size,
 ):
+    file_paths = []
+    if isinstance(files, list):
+        for f in files:
+            file_paths.append(f if isinstance(f, str) else f.name)
+    elif files is not None:
+        file_paths.append(files if isinstance(files, str) else files.name)
+
+    if not file_paths:
+        return "No files provided"
+
     return tag_images(
-        targets_path=targets_path,
-        recursive=recursive,
+        targets_path=file_paths,
+        recursive=False,
         dry_run=dry_run,
         model_folder=model_folder,
         tags_csv=tags_csv,
@@ -78,7 +88,7 @@ def main():
         gr.Markdown("# WD Mass Tagger")
         with gr.Tabs():
             with gr.TabItem("Batch Tag"):
-                targets = gr.Textbox(label="Targets Path")
+                targets = gr.Files(label="Images")
                 recursive = gr.Checkbox(label="Recursive")
                 dry_run = gr.Checkbox(label="Dry Run")
                 model_folder = gr.Dropdown(

--- a/mass_tagger.py
+++ b/mass_tagger.py
@@ -126,11 +126,32 @@ def tag_images(
     batch_size=32,
     gpu_id=0,
 ):
-    """Tag all images in a directory using a WD14 tagger model."""
+    """Tag images from a path or list using a WD14 tagger model."""
 
     glob_pattern = "**/*" if recursive else "*"
 
-    targets_path = Path(targets_path)
+    image_extensions = [".jpeg", ".jpg", ".png", ".webp"]
+
+    if isinstance(targets_path, (list, tuple)):
+        images_list = [
+            str(Path(p).resolve())
+            for p in targets_path
+            if Path(p).suffix.lower() in image_extensions
+        ]
+    else:
+        targets_path = Path(targets_path)
+        if targets_path.is_file():
+            images_list = (
+                [str(targets_path.resolve())]
+                if targets_path.suffix.lower() in image_extensions
+                else []
+            )
+        else:
+            images_list = [
+                str(p.resolve())
+                for p in targets_path.glob(glob_pattern)
+                if p.suffix.lower() in image_extensions
+            ]
 
     model, height, width, model_path = _load_model(model_folder)
 
@@ -139,21 +160,6 @@ def tag_images(
         candidate = Path(model_path) / labels_file
         if candidate.is_file():
             labels_file = str(candidate)
-
-    image_extensions = [".jpeg", ".jpg", ".png", ".webp"]
-
-    if targets_path.is_file():
-        images_list = (
-            [str(targets_path.resolve())]
-            if targets_path.suffix.lower() in image_extensions
-            else []
-        )
-    else:
-        images_list = [
-            str(p.resolve())
-            for p in targets_path.glob(glob_pattern)
-            if p.suffix.lower() in image_extensions
-        ]
 
     # https://github.com/toriato/stable-diffusion-webui-wd14-tagger/blob/a9eacb1eff904552d3012babfa28b57e1d3e295c/tagger/ui.py#L368
 


### PR DESCRIPTION
## Summary
- allow `tag_images` to take a list of files
- update gradio app to use `gr.Files` for batch tagging
- document new batch upload workflow

## Testing
- `python3 -m py_compile mass_tagger.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686570f713248330a3f667e2add249e5