### PR TITLE
Add share flag to Gradio app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The script writes a `.txt` file next to each image containing the predicted tags
 Launch the Gradio web UI with:
 
 ```bash
-python3 gradio_app.py
+python3 gradio_app.py [--share]
 ```
 
-This starts a local server where you can configure the options interactively and run the tagger through a browser interface.
+Use the optional `--share` flag (or set the `SHARE=1` environment variable) to create a public link. This starts a local server where you can configure the options interactively and run the tagger through a browser interface.

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import argparse
 import gradio as gr
 from mass_tagger import tag_images, _load_model
 
@@ -59,6 +60,16 @@ def run_single(upload, model_folder, tags_csv, threshold):
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Launch the WD Mass Tagger UI")
+    parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Create a public Gradio link (can also set SHARE=1)",
+    )
+    args = parser.parse_args()
+
+    share_flag = args.share or os.getenv("SHARE", "").lower() in ["1", "true", "yes"]
+
     models = [
         "SmilingWolf/wd-eva02-large-tagger-v3",
         "SmilingWolf/wd-vit-large-tagger-v3",
@@ -132,7 +143,7 @@ def main():
                     show_progress="full",
                 )
     demo.queue()
-    demo.launch(share=True)
+    demo.launch(share=share_flag)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow passing `--share` or env var `SHARE` to share the Gradio interface
- document the flag in the README

## Testing
- `python3 -m py_compile gradio_app.py`
- `python3 -m py_compile mass_tagger.py`


------
https://chatgpt.com/codex/tasks/task_e_686570f588008330b08fa7fd09281ddf