### PR TITLE
Add install and launch scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 
 # Virtual environment directories
 venv/
+.venv/
 env/
 ENV/
 .pip/

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repository provides scripts for tagging batches of images using Waifu Diffu
 
 ## Installation
 
-Install the Python dependencies with pip:
+Run the setup script to create a virtual environment and install the required
+packages:
 
 ```bash
-python3 -m pip install -r requirements.txt
+./install.sh
 ```
 
 ## Command Line Usage
@@ -45,4 +46,14 @@ This starts a local server where you can configure the options interactively and
 Passing `--share` or setting the environment variable `GRADIO_SHARE=1` will share the interface publicly via Gradio.
 
 In the *Batch Tag* tab, use the **Images** file uploader to select the pictures you want to tag. The selected files are processed on the server and the resulting tags are written next to each uploaded image.
+
+## Launch
+
+Use the helper script to start the Gradio interface from the virtual environment:
+
+```bash
+./launch.sh [--share]
+```
+
+Any arguments passed to `launch.sh` are forwarded to `gradio_app.py`.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Create virtual environment
+python3 -m venv .venv
+
+# Activate and install dependencies
+source .venv/bin/activate
+pip install -r requirements.txt
+

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Run the Gradio application
+python gradio_app.py "$@"
+


### PR DESCRIPTION
## Summary
- add `install.sh` to automate virtual environment setup
- add `launch.sh` to run the Gradio interface using the venv
- document the new scripts in the README
- ignore `.venv` in git

## Testing
- `python -m py_compile mass_tagger.py gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68658223b3c883308968f0c582ecd724