### PR TITLE
Add desktop entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ Use the helper script to start the Gradio interface from the virtual environment
 
 Any arguments passed to `launch.sh` are forwarded to `gradio_app.py`.
 
+## Desktop Shortcut
+
+Copy the provided `wdmass-tagger.desktop` file to `~/.local/share/applications` so that WD Mass Tagger appears in your application menu.
+
+Place your own icon at `assets/icon.png` if you want the shortcut to display one.
+

--- a/wdmass-tagger.desktop
+++ b/wdmass-tagger.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=WD Mass Tagger
+Exec=launch.sh
+Icon=assets/icon.png
+Terminal=false


### PR DESCRIPTION
## Summary
- include a placeholder path for the desktop icon
- remove the bundled `icon.png`
- note how to supply a custom icon

## Testing
- `python3 -m py_compile mass_tagger.py gradio_app.py`
- `bash -n install.sh`
- `bash -n launch.sh`


------
https://chatgpt.com/codex/tasks/task_e_686587db80cc83309c17d18dae02d5f4